### PR TITLE
Add no net label export corpus to allow "no net label matching" 

### DIFF
--- a/dist-types.d.ts
+++ b/dist-types.d.ts
@@ -3,6 +3,11 @@ declare module "dist/bundled-bpc-graphs.json" {
   export default value
 }
 
+declare module "dist/bundled-bpc-graphs-no-net-label.json" {
+  const value: Record<string, any>
+  export default value
+}
+
 declare module "dist/svg-vfs.js" {
   const value: Record<string, any>
   export default value

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,6 @@
+export { default as corpusNoNetLabel } from "dist/bundled-bpc-graphs-no-net-label.json" with {
+  type: "json",
+}
 import corpus from "dist/bundled-bpc-graphs.json" with { type: "json" }
 
 export default corpus

--- a/scripts/create-bpcs.ts
+++ b/scripts/create-bpcs.ts
@@ -43,7 +43,7 @@ async function main() {
     const netLabelBoxIds = bpcNoNetLabel.boxes
       .filter((box) => {
         const boxPins = bpcNoNetLabel.pins.filter((p) => p.boxId === box.boxId)
-        return !boxPins.some((p) => p.color === "netlabel_center")
+        return boxPins.some((p) => p.color === "netlabel_center")
       })
       .map((b) => b.boxId)
     bpcNoNetLabel.boxes = bpcNoNetLabel.boxes.filter(
@@ -55,7 +55,10 @@ async function main() {
     )
 
     const outPathNoNetLabel = join(dir, "bpc-no-net-label.json")
-    await fs.writeFile(outPath, JSON.stringify(bpc, null, 2))
+    await fs.writeFile(
+      outPathNoNetLabel,
+      JSON.stringify(bpcNoNetLabel, null, 2),
+    )
 
     const graphics = getGraphicsForBpcGraph(bpc)
     const svg = getSvgFromGraphicsObject(graphics, { backgroundColor: "white" })

--- a/scripts/create-bpcs.ts
+++ b/scripts/create-bpcs.ts
@@ -2,7 +2,7 @@
 import { convertCircuitJsonToBpc } from "circuit-json-to-bpc"
 import { promises as fs } from "fs"
 import { join, dirname, basename } from "path"
-import { getGraphicsForBpcGraph } from "bpc-graph"
+import { getGraphicsForBpcGraph, type FixedBpcGraph } from "bpc-graph"
 import { getSvgFromGraphicsObject } from "graphics-debug"
 
 async function getCircuitFiles(dir: string): Promise<string[]> {
@@ -29,7 +29,8 @@ async function main() {
     return
   }
 
-  const bundled: Record<string, unknown> = {}
+  const bundledCorpus: Record<string, unknown> = {}
+  const bundledCorpusNoNetLabel: Record<string, unknown> = {}
 
   for (const file of circuitFiles) {
     const circuitJson = JSON.parse(await fs.readFile(file, "utf8"))
@@ -38,18 +39,57 @@ async function main() {
     const outPath = join(dir, "bpc.json")
     await fs.writeFile(outPath, JSON.stringify(bpc, null, 2))
 
+    const bpcNoNetLabel: FixedBpcGraph = structuredClone(bpc) as any
+    const netLabelBoxIds = bpcNoNetLabel.boxes
+      .filter((box) => {
+        const boxPins = bpcNoNetLabel.pins.filter((p) => p.boxId === box.boxId)
+        return !boxPins.some((p) => p.color === "netlabel_center")
+      })
+      .map((b) => b.boxId)
+    bpcNoNetLabel.boxes = bpcNoNetLabel.boxes.filter(
+      (b) => !netLabelBoxIds.includes(b.boxId),
+    )
+
+    bpcNoNetLabel.pins = bpcNoNetLabel.pins.filter(
+      (p) => !netLabelBoxIds.includes(p.boxId),
+    )
+
+    const outPathNoNetLabel = join(dir, "bpc-no-net-label.json")
+    await fs.writeFile(outPath, JSON.stringify(bpc, null, 2))
+
     const graphics = getGraphicsForBpcGraph(bpc)
     const svg = getSvgFromGraphicsObject(graphics, { backgroundColor: "white" })
     const svgPath = join(dir, "bpc.svg")
     await fs.writeFile(svgPath, svg)
 
+    const graphicsNoNetLabel = getGraphicsForBpcGraph(bpcNoNetLabel)
+    const svgNoNetLabel = getSvgFromGraphicsObject(graphicsNoNetLabel, {
+      backgroundColor: "white",
+    })
+    const svgPathNoNetLabel = join(dir, "bpc-no-net-label.svg")
+    await fs.writeFile(svgPathNoNetLabel, svgNoNetLabel)
+
     const designName = basename(dir)
-    bundled[designName] = bpc
+
+    bundledCorpus[designName] = bpc
+    bundledCorpusNoNetLabel[designName] = bpcNoNetLabel
   }
 
   const bundledPath = join(distDir, "bundled-bpc-graphs.json")
-  await fs.writeFile(bundledPath, JSON.stringify(bundled, null, 2))
+  await fs.writeFile(bundledPath, JSON.stringify(bundledCorpus, null, 2))
   console.log(`Wrote ${circuitFiles.length} BPC graphs to ${bundledPath}`)
+
+  const bundledPathNoNetLabel = join(
+    distDir,
+    "bundled-bpc-graphs-no-net-label.json",
+  )
+  await fs.writeFile(
+    bundledPathNoNetLabel,
+    JSON.stringify(bundledCorpusNoNetLabel, null, 2),
+  )
+  console.log(
+    `Wrote ${circuitFiles.length} BPC graphs to ${bundledPathNoNetLabel}`,
+  )
 }
 
 main().catch((err) => {


### PR DESCRIPTION
- **export bpc graphs with no net label**
- **fix bpc no net label output**
