### PR TITLE
Expose SVGs on site build

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "vercel-build": "bun run build && bun run build:site",
     "build": "tsci build --ignore-errors && bun run ./scripts/create-bpcs.ts && bun build lib/index.ts --outfile ./dist/index.js && cp ./lib/index.d.ts ./dist/index.d.ts",
     "build:svgs": "make-vfs --dir ./designs/__snapshots__ --outfile ./dist/svg-vfs.js --content-format string",
-    "build:site": "bun run build:svgs && bun build ./site/index.html --outdir ./dist-site",
+    "build:site": "bun run build:svgs && bun build ./site/index.html --outdir ./dist-site && bun run ./scripts/copy-svgs-to-site.ts",
     "start:site": "bun run ./site/index.html",
     "snapshot": "tsci snapshot --schematic-only",
     "snapshot:update": "tsci snapshot --update --schematic-only",

--- a/scripts/copy-svgs-to-site.ts
+++ b/scripts/copy-svgs-to-site.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bun
+import { promises as fs } from "fs"
+import { join, dirname } from "path"
+
+async function main() {
+  const scriptDir = dirname(new URL(import.meta.url).pathname)
+  const snapshotsDir = join(scriptDir, "..", "designs", "__snapshots__")
+  const outDir = join(scriptDir, "..", "dist-site")
+  await fs.mkdir(outDir, { recursive: true })
+  const files = await fs.readdir(snapshotsDir)
+  for (const file of files) {
+    if (!file.endsWith(".svg")) continue
+    const m = file.match(/^(design\d+)\.circuit-schematic\.snap\.svg$/)
+    if (!m) continue
+    const destName = `${m[1]}.svg`
+    await fs.copyFile(join(snapshotsDir, file), join(outDir, destName))
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- add a copy-svgs-to-site script to collect snapshots for serving
- invoke copy-svgs-to-site as part of `build:site`

## Testing
- `bun run build && bun run build:site`
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_686eddf60e10832eb025a0588c0049b5