### PR TITLE
Fix build script path resolution

### DIFF
--- a/scripts/copy-svgs-to-site.ts
+++ b/scripts/copy-svgs-to-site.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env bun
 import { promises as fs } from "fs"
 import { join, dirname } from "path"
+import { fileURLToPath } from "url"
 
 async function main() {
-  const scriptDir = dirname(new URL(import.meta.url).pathname)
+  const scriptDir = dirname(fileURLToPath(import.meta.url))
   const snapshotsDir = join(scriptDir, "..", "designs", "__snapshots__")
   const outDir = join(scriptDir, "..", "dist-site")
   await fs.mkdir(outDir, { recursive: true })


### PR DESCRIPTION
## Summary
- fix `copy-svgs-to-site.ts` path resolution using `fileURLToPath`

## Testing
- `bun test`
- `bun run build:site`

------
https://chatgpt.com/codex/tasks/task_b_686f34d21b50832ebc1bc0482b281bc5