### PR TITLE
Fix site import for graphs

### DIFF
--- a/dist-types.d.ts
+++ b/dist-types.d.ts
@@ -3,6 +3,11 @@ declare module "dist/bundled-bpc-graphs.json" {
   export default value
 }
 
+declare module "@tscircuit/schematic-corpus/dist/bundled-bpc-graphs.json" {
+  const value: Record<string, any>
+  export default value
+}
+
 declare module "dist/bundled-bpc-graphs-no-net-label.json" {
   const value: Record<string, any>
   export default value

--- a/site/main.tsx
+++ b/site/main.tsx
@@ -2,7 +2,7 @@ import React from "react"
 import { createRoot } from "react-dom/client"
 import { getGraphicsForBpcGraph } from "bpc-graph"
 import { getSvgFromGraphicsObject } from "graphics-debug"
-import bundledBpcGraphs from "dist/bundled-bpc-graphs.json"
+import bundledBpcGraphs from "@tscircuit/schematic-corpus/dist/bundled-bpc-graphs.json"
 // @ts-ignore – generated at build time
 import circuitSvgs from "dist/svg-vfs.js" // Record<designName, raw <svg…> string>
 


### PR DESCRIPTION
## Summary
- load bundled BPC graphs from installed package instead of local dist
- provide type declarations for the new import path

## Testing
- `bun run format`

------
https://chatgpt.com/codex/tasks/task_b_686f34d21b50832ebc1bc0482b281bc5